### PR TITLE
Updated Sales class with report versions 1_1

### DIFF
--- a/lib/itc-reporter.js
+++ b/lib/itc-reporter.js
@@ -33,11 +33,27 @@ class ITCReporter {
   }
 }
 class Sales extends ITCReporter {
+  static get reportVersions() {
+    return {
+      'Subscriber,Detailed': '1_1',
+      'Subscription,Summary': '1_1',
+      'SubscriptionEvent,Summary': '1_1',
+    };
+  }
+
+  static getReportVersion(param) {
+    const version = Sales.reportVersions[`${param.reportType},${param.reportSubType}`];
+    return version;
+  }
   getVendors() {
     return this.request('getVendors');
   }
   getReport(param) {
-    const command = `getReport, ${param.vendorNumber},${param.reportType},${param.reportSubType},${param.dateType},${param.date}`;
+    let command = `getReport, ${param.vendorNumber},${param.reportType},${param.reportSubType},${param.dateType},${param.date}`;
+    const version = Sales.getReportVersion(param);
+    if (version) {
+      command += `,${version}`;
+    }
     return this.request(command);
   }
 }

--- a/test/itc-reporter.js
+++ b/test/itc-reporter.js
@@ -11,50 +11,50 @@ describe('Sales', () => {
     password: 'YYY',
     mode: 'Robot.XML',
   });
-  it('getVersion', done => {
+  it('getVersion', (done) => {
     assert(reporter.getVersion(), '1.0');
     done();
   });
-  it('getStatus', done => {
+  it('getStatus', (done) => {
     nock('https://reportingitc-reporter.apple.com')
       .post('/reportservice/sales/v1')
       .reply(200, 'ok');
 
     const stream = reporter.getStatus();
-    const writer =  new memoryStream.WritableStream();
+    const writer = new memoryStream.WritableStream();
     stream.pipe(writer);
     stream.on('end', () => {
       assert(writer.toString());
       done();
     });
   });
-  it('getAccounts', done => {
+  it('getAccounts', (done) => {
     nock('https://reportingitc-reporter.apple.com')
       .post('/reportservice/sales/v1')
       .reply(200, 'ok');
 
     const stream = reporter.getAccounts();
-    const writer =  new memoryStream.WritableStream();
+    const writer = new memoryStream.WritableStream();
     stream.pipe(writer);
     stream.on('end', () => {
       assert(writer.toString());
       done();
     });
   });
-  it('getVendors', done => {
+  it('getVendors', (done) => {
     nock('https://reportingitc-reporter.apple.com')
       .post('/reportservice/sales/v1')
       .reply(200, 'ok');
 
     const stream = reporter.getVendors();
-    const writer =  new memoryStream.WritableStream();
+    const writer = new memoryStream.WritableStream();
     stream.pipe(writer);
     stream.on('end', () => {
       assert(writer.toString());
       done();
     });
   });
-  it('getReport', done => {
+  it('getReport', (done) => {
     nock('https://reportingitc-reporter.apple.com')
       .post('/reportservice/sales/v1')
       .reply(200, 'ok');
@@ -66,7 +66,38 @@ describe('Sales', () => {
       dateType: 'Daily',
       date: '20160101',
     });
-    const writer =  new memoryStream.WritableStream();
+    const writer = new memoryStream.WritableStream();
+    stream.pipe(writer);
+    stream.on('end', () => {
+      assert(writer.toString());
+      done();
+    });
+  });
+
+  it('getReport with correct version', (done) => {
+    nock('https://reportingitc-reporter.apple.com')
+      .post('/reportservice/sales/v1')
+      .reply((uri, body, cb) => {
+        const jsonRequest = JSON.parse(decodeURIComponent(body.replace('jsonRequest=', '')));
+        const { queryInput } = jsonRequest;
+        if (queryInput.indexOf('Subscriber,Detailed') >= 0
+            || queryInput.indexOf('Subscription,Summary') >= 0
+            || queryInput.indexOf('SubscriptionEvent,Summary') >= 0) {
+          if (queryInput.indexOf('1_1') < 0) {
+            return cb('Report version should be 1_1');
+          }
+        }
+        return cb(null, 'ok');
+      });
+
+    const stream = reporter.getReport({
+      vendorNumber: 9999999,
+      reportType: 'Subscriber',
+      reportSubType: 'Detailed',
+      dateType: 'Daily',
+      date: '20160101',
+    });
+    const writer = new memoryStream.WritableStream();
     stream.pipe(writer);
     stream.on('end', () => {
       assert(writer.toString());
@@ -81,50 +112,50 @@ describe('Finance', () => {
     password: 'YYY',
     mode: 'Robot.XML',
   });
-  it('getVersion', done => {
+  it('getVersion', (done) => {
     assert(reporter.getVersion(), '1.0');
     done();
   });
-  it('getStatus', done => {
+  it('getStatus', (done) => {
     nock('https://reportingitc-reporter.apple.com')
       .post('/reportservice/finance/v1')
       .reply(200, 'ok');
 
     const stream = reporter.getStatus();
-    const writer =  new memoryStream.WritableStream();
+    const writer = new memoryStream.WritableStream();
     stream.pipe(writer);
     stream.on('end', () => {
       assert(writer.toString());
       done();
     });
   });
-  it('getAccounts', done => {
+  it('getAccounts', (done) => {
     nock('https://reportingitc-reporter.apple.com')
       .post('/reportservice/finance/v1')
       .reply(200, 'ok');
 
     const stream = reporter.getAccounts();
-    const writer =  new memoryStream.WritableStream();
+    const writer = new memoryStream.WritableStream();
     stream.pipe(writer);
     stream.on('end', () => {
       assert(writer.toString());
       done();
     });
   });
-  it('getVendorsAndRegions', done => {
+  it('getVendorsAndRegions', (done) => {
     nock('https://reportingitc-reporter.apple.com')
       .post('/reportservice/finance/v1')
       .reply(200, 'ok');
 
     const stream = reporter.getVendorsAndRegions();
-    const writer =  new memoryStream.WritableStream();
+    const writer = new memoryStream.WritableStream();
     stream.pipe(writer);
     stream.on('end', () => {
       assert(writer.toString());
       done();
     });
   });
-  it('getReport', done => {
+  it('getReport', (done) => {
     nock('https://reportingitc-reporter.apple.com')
       .post('/reportservice/finance/v1')
       .reply(200, 'ok');
@@ -135,7 +166,7 @@ describe('Finance', () => {
       fiscalYear: 2016,
       fiscalPeriod: 8,
     });
-    const writer =  new memoryStream.WritableStream();
+    const writer = new memoryStream.WritableStream();
     stream.pipe(writer);
     stream.on('end', () => {
       assert(writer.toString());


### PR DESCRIPTION
Added version to 1_1 sales reports: `Subscriber,Detailed`, `Subscription,Summary` and `SubscriptionEvent,Summary`

Send version parameter only for reports with version 1_1. For version 1_0 reports the version is not required.

Tests:
Added a simple test for Sales reports version and fixed lint in tests.

Fixes #5 